### PR TITLE
Rename functions for consistency

### DIFF
--- a/FRP/Euphoria/Event.hs
+++ b/FRP/Euphoria/Event.hs
@@ -50,7 +50,7 @@ module FRP.Euphoria.Event
 -- ** Other event operations
 , delayE
 , dropStepE
-, effectfulEE
+, mapEIO
 , memoE
 , joinEventSignal
 , generatorE
@@ -281,8 +281,8 @@ expandE (Event evt) = Event $ f <$> evt
         f xs = [xs]
 
 -- | Like 'mapM' over events.
-effectfulEE :: (t -> IO a) -> Event t -> SignalGen (Event a)
-effectfulEE mkAction (Event evt) = Event <$> effectful1 (mapM mkAction) evt
+mapEIO :: (t -> IO a) -> Event t -> SignalGen (Event a)
+mapEIO mkAction (Event evt) = Event <$> effectful1 (mapM mkAction) evt
 
 -- | Memoization of events. See the doc for 'FRP.Elerea.Simple.memo'.
 memoE :: Event a -> SignalGen (Event a)

--- a/FRP/Euphoria/Update.hs
+++ b/FRP/Euphoria/Update.hs
@@ -108,7 +108,7 @@ mappendUpdateIO d1 d2 = unIOMonoid <$> ((IOMonoid <$> d1) `mappend` (IOMonoid <$
 instance (Monoid a) => SignalSet (Update a) where
     basicSwitchD dis = do
         updatesE <- preservesD dis
-        dynUpdatesE <- effectfulEE mkDynUpdates updatesE
+        dynUpdatesE <- mapEIO mkDynUpdates updatesE
         dynUpdatesD <- stepperD undefined dynUpdatesE
         dynE <- switchD dynUpdatesD
         initial <- execute newDynUpdateState


### PR DESCRIPTION
Some functions are named inconsistently. I propose renaming them.
