### PR TITLE
Allow the creaton of Collections from other map types

### DIFF
--- a/FRP/Euphoria/Collection.hs
+++ b/FRP/Euphoria/Collection.hs
@@ -23,8 +23,10 @@ module FRP.Euphoria.Collection
 , emptyCollection
 , collectionFromList
 , collectionFromDiscreteList
-, mapToCollection
 , makeCollection
+, mapToCollection
+, enummapToCollection
+, hashmapToCollection
 -- * observing collections
 , watchCollection
 , followCollectionKey
@@ -39,15 +41,16 @@ module FRP.Euphoria.Collection
 , sequenceCollection
 ) where
 
-import Control.Applicative
 import Control.Monad (join)
 import Data.EnumMap.Lazy (EnumMap)
 import qualified Data.EnumMap.Lazy as EnumMap
+import Data.Hashable (Hashable)
+import Data.HashMap.Strict (HashMap)
+import qualified Data.HashMap.Strict as HMS
 import Data.List
+import Data.Map (Map)
+import qualified Data.Map as Map
 import Data.Maybe (mapMaybe)
-import Data.Traversable
-import Data.Foldable (Foldable)
-import Data.Monoid
 
 import FRP.Euphoria.Event
 
@@ -297,13 +300,32 @@ stepListCollState xs (initialK, existingMap) = ((k', newMap'), removeUpdates ++ 
 -------------------------------------------------------------------------------
 -- Converting Discrete Maps into Collections
 
-mapToCollection :: forall k a.
-                  (Enum k, Eq k, Eq a)
-                => Discrete (EnumMap k a)
-                -> SignalGen (Collection k (Discrete a))
-mapToCollection mapD =
+mapToCollection
+    :: (Eq k, Eq a, Ord k)
+    => Discrete (Map k a)
+    -> SignalGen (Collection k (Discrete a))
+mapToCollection =
+    genericMapToCollection Map.empty $
+        diffMaps (Map.\\) Map.intersection Map.lookup Map.toList
+
+enummapToCollection
+    :: (Eq k, Eq a, Enum k)
+    => Discrete (EnumMap k a)
+    -> SignalGen (Collection k (Discrete a))
+enummapToCollection =
     genericMapToCollection EnumMap.empty $
         diffMaps (EnumMap.\\) EnumMap.intersection EnumMap.lookup EnumMap.toList
+
+hashmapToCollection
+    :: (Eq k, Eq a, Hashable k)
+    => Discrete (HashMap k a)
+    -> SignalGen (Collection k (Discrete a))
+hashmapToCollection =
+    genericMapToCollection HMS.empty $
+        diffMaps HMS.difference HMS.intersection HMS.lookup HMS.toList
+
+-- Generic implementation
+--------------------------
 
 data MapCollEvent k a
     = MCNew k a

--- a/FRP/Euphoria/Internal/Maplike.hs
+++ b/FRP/Euphoria/Internal/Maplike.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleInstances #-}
+
+-- NOTE (asayers): I suppose this module doesn't really belong in
+-- euphoria... but I don't think it deserves its own package.
+module FRP.Euphoria.Internal.Maplike
+    ( Maplike(..)
+    ) where
+
+import Data.Hashable (Hashable)
+import qualified Data.Map            as Map
+import qualified Data.HashMap.Strict as HMS
+import qualified Data.EnumMap.Lazy   as EML
+
+-- | A class for types with an API similar to that of "Data.Map".
+class Maplike c k where
+    union        :: c k v -> c k v -> c k v
+    intersection :: c k v -> c k v -> c k v
+    difference   :: c k v -> c k v -> c k v
+    empty        :: c k v
+    lookup       :: k -> c k v -> Maybe v
+    singleton    :: k -> v -> c k v
+    singleton k v = insert k v empty
+    insert :: k -> v -> c k v -> c k v
+    insert k v m = singleton k v `union` m
+    delete :: k -> c k v -> c k v
+    delete k m =  m `difference` singleton k (error "bug")
+    toList :: c k v -> [(k, v)]
+
+instance Ord k => Maplike Map.Map k where
+    union        = Map.union
+    intersection = Map.intersection
+    difference   = (Map.\\)
+    empty        = Map.empty
+    lookup       = Map.lookup
+    singleton    = Map.singleton
+    insert       = Map.insert
+    delete       = Map.delete
+    toList       = Map.toList
+
+instance Enum k => Maplike EML.EnumMap k where
+    union        = EML.union
+    intersection = EML.intersection
+    difference   = (EML.\\)
+    empty        = EML.empty
+    lookup       = EML.lookup
+    singleton    = EML.singleton
+    insert       = EML.insert
+    delete       = EML.delete
+    toList       = EML.toList
+
+instance (Eq k, Hashable k) => Maplike HMS.HashMap k where
+    union        = HMS.union
+    intersection = HMS.intersection
+    difference   = HMS.difference
+    empty        = HMS.empty
+    lookup       = HMS.lookup
+    singleton    = HMS.singleton
+    insert       = HMS.insert
+    delete       = HMS.delete
+    toList       = HMS.toList

--- a/euphoria.cabal
+++ b/euphoria.cabal
@@ -4,7 +4,7 @@
 name:                euphoria
 version:             0.4.9.0
 synopsis:            Dynamic network FRP with events and continuous values
-description:         
+description:
 
  Euphoria is FRP with practicality.
  .
@@ -62,7 +62,7 @@ license:             PublicDomain
 license-file:        LICENSE
 author:              Takano Akio, Andrew Richards, Liyang HU
 maintainer:          aljee@hyper.cx <Takano Akio>
--- copyright:           
+-- copyright:
 category:            FRP
 build-type:          Simple
 cabal-version:       >=1.8
@@ -74,8 +74,16 @@ source-repository head
 
 library
   exposed-modules:     FRP.Euphoria.Event, FRP.Euphoria.Signal, FRP.Euphoria.Update, FRP.Euphoria.Collection, FRP.Euphoria.Abbrev
-  -- other-modules:       
-  build-depends:       HUnit, base, elerea >= 2.7, data-default, enummapset-th >= 0.6, deepseq
+  -- other-modules:
+  build-depends:       HUnit
+                     , base
+                     , elerea >= 2.7
+                     , data-default
+                     , enummapset-th >= 0.6
+                     , deepseq
+                     , hashable >= 1.2
+                     , containers >= 0.5.6
+                     , unordered-containers >= 0.2.5
 
 test-suite tests
   type:           exitcode-stdio-1.0

--- a/euphoria.cabal
+++ b/euphoria.cabal
@@ -2,7 +2,7 @@
 -- see http://haskell.org/cabal/users-guide/
 
 name:                euphoria
-version:             0.4.9.0
+version:             0.5.0.0
 synopsis:            Dynamic network FRP with events and continuous values
 description:
 


### PR DESCRIPTION
This MR adds support for `HashMap`s and `Map`s, in addition to `EnumMap`s.

Note: This is an API-breaking change, since it changes the type signature of `mapToCollection`.