### PR TITLE
Allow the creaton of Collections from other map types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: haskell
+ghc: "7.8"
 
 before_install:
   - ./.travis.install-deps $mode --constraint="bytestring installed" --force-reinstalls
@@ -16,4 +17,3 @@ env:
 
 notifications:
   email: false
-

--- a/FRP/Euphoria/Collection.hs
+++ b/FRP/Euphoria/Collection.hs
@@ -42,6 +42,8 @@ module FRP.Euphoria.Collection
 ) where
 
 
+import Prelude hiding (lookup)
+
 #if __GLASGOW_HASKELL__ < 710
 import Control.Applicative ((<$>), (<*>), (<$), pure)
 import Data.Foldable (Foldable)
@@ -54,13 +56,12 @@ import Data.EnumMap.Lazy (EnumMap)
 import qualified Data.EnumMap.Lazy as EnumMap
 import Data.Hashable (Hashable)
 import Data.HashMap.Strict (HashMap)
-import qualified Data.HashMap.Strict as HMS
-import Data.List
+import Data.List hiding (insert, lookup)
 import Data.Map (Map)
-import qualified Data.Map as Map
 import Data.Maybe (mapMaybe)
 
 import FRP.Euphoria.Event
+import qualified FRP.Euphoria.Internal.Maplike as M
 
 
 -- | Represents an incremental change to a collection of items.
@@ -312,25 +313,19 @@ mapToCollection
     :: (Eq k, Eq a, Ord k)
     => Discrete (Map k a)
     -> SignalGen (Collection k (Discrete a))
-mapToCollection =
-    genericMapToCollection Map.empty $
-        diffMaps (Map.\\) Map.intersection Map.lookup Map.toList
+mapToCollection = genericMapToCollection
 
 enummapToCollection
     :: (Eq k, Eq a, Enum k)
     => Discrete (EnumMap k a)
     -> SignalGen (Collection k (Discrete a))
-enummapToCollection =
-    genericMapToCollection EnumMap.empty $
-        diffMaps (EnumMap.\\) EnumMap.intersection EnumMap.lookup EnumMap.toList
+enummapToCollection = genericMapToCollection
 
 hashmapToCollection
     :: (Eq k, Eq a, Hashable k)
     => Discrete (HashMap k a)
     -> SignalGen (Collection k (Discrete a))
-hashmapToCollection =
-    genericMapToCollection HMS.empty $
-        diffMaps HMS.difference HMS.intersection HMS.lookup HMS.toList
+hashmapToCollection = genericMapToCollection
 
 -- Generic implementation
 --------------------------
@@ -348,37 +343,33 @@ data MapCollEvent k a
 -- Discrete value updated, and keys with values that are still present
 -- will not have their Discrete values updated.
 genericMapToCollection
-    :: forall c k a. (Eq k)
-    => c k a                                  -- ^ Empty map
-    -> (c k a -> c k a -> [MapCollEvent k a]) -- ^ Function for diffing maps
-    -> Discrete (c k a)                       -- ^ A discrete of maps
+    :: forall c k a. (Eq k, Eq a, M.Maplike c k)
+    => Discrete (c k a)
     -> SignalGen (Collection k (Discrete a))
-genericMapToCollection emptyMap diffFn mapD = do
-    m1 <- delayD emptyMap mapD
+genericMapToCollection mapD = do
+    m1 <- delayD M.empty mapD
     let collDiffs :: Discrete [MapCollEvent k a]
-        collDiffs = diffFn <$> m1 <*> mapD
+        collDiffs = diffMaps <$> m1 <*> mapD
     dispatchCollEvent . flattenE =<< preservesD collDiffs
 
 -- | Given a pair of generic maps, compute a sequence of "MapCollEvent"s
 -- which would transform the first into the second.
 diffMaps
-    :: (Eq a)
-    => (c k a -> c k a -> c k a) -- ^ Difference
-    -> (c k a -> c k a -> c k a) -- ^ Intersection
-    -> (k -> c k a -> Maybe a)   -- ^ Lookup
-    -> (c k a -> [(k, a)])       -- ^ To list
-    -> c k a -> c k a -> [MapCollEvent k a]
-diffMaps difference intersection mapLookup toList prevmap newmap = concat
+    :: (Eq a, M.Maplike c k)
+    => c k a
+    -> c k a
+    -> [MapCollEvent k a]
+diffMaps prevmap newmap = concat
     [ map (uncurry MCNew   ) newStuff
     , map (MCRemove . fst  ) removedStuff
     , map (uncurry MCChange) changedStuff
     ]
   where
-    newStuff     = toList $ newmap `difference` prevmap
-    removedStuff = toList $ prevmap `difference` newmap
-    keptStuff    = toList $ newmap `intersection` prevmap
+    newStuff     = M.toList $ newmap `M.difference` prevmap
+    removedStuff = M.toList $ prevmap `M.difference` newmap
+    keptStuff    = M.toList $ newmap `M.intersection` prevmap
     changedStuff = mapMaybe justChanges keptStuff
-    justChanges (k, v1) = case mapLookup k prevmap of
+    justChanges (k, v1) = case M.lookup k prevmap of
         Just v2 | v1 /= v2  -> Just (k, v1)
         _ -> Nothing
 

--- a/FRP/Euphoria/Collection.hs
+++ b/FRP/Euphoria/Collection.hs
@@ -4,13 +4,9 @@
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE RecursiveDo #-}
 {-# OPTIONS_GHC -Wall #-}
 
-#if __GLASGOW_HASKELL__ <= 706
-{-# LANGUAGE DoRec #-}
-#else
-{-# LANGUAGE RecursiveDo #-}
-#endif
 
 -- | Collection signals with incremental updates.
 module FRP.Euphoria.Collection

--- a/FRP/Euphoria/Collection.hs
+++ b/FRP/Euphoria/Collection.hs
@@ -59,6 +59,7 @@ import Data.HashMap.Strict (HashMap)
 import Data.List hiding (insert, lookup)
 import Data.Map (Map)
 import Data.Maybe (mapMaybe)
+import Data.Proxy (Proxy(..))
 
 import FRP.Euphoria.Event
 import qualified FRP.Euphoria.Internal.Maplike as M
@@ -209,32 +210,30 @@ simpleCollectionUpdates initialK evs = do
         updateAddItem (k, a, _) = AddItem k a
     memoE $ (updateAddItem <$> newEvents) `mappend` (RemoveItem <$> removalEvent)
 
--- Turns adds the necessary state for holding the existing [(k, a)]
--- and creating the unique Event stream for each change of the
--- collection.
-accumCollection :: (Enum k)
-                => Event (CollectionUpdate k a)
-                -> SignalGen (Collection k a)
-accumCollection ev = do
-    let toMapOp (AddItem k a) = EnumMap.insert k a
-        toMapOp (RemoveItem k) = EnumMap.delete k
-    mapping <- accumD EnumMap.empty (toMapOp <$> ev)
-    listD <- memoD $ EnumMap.toList <$> mapping
-    makeCollection listD ev
-
--- Adding elemenets is faster than "accumCollection", but deleting them is
--- slower. Note that the semantics differ in the case of adding the same
--- key multiple times. "accumCollection" replaces, whereas
--- "genericAccumCollection" allows multiple copies.
-genericAccumCollection
-    :: (Eq k)
+-- Adds the necessary state for holding the existing [(k, a)] and creating
+-- the unique Event stream for each change of the collection.
+accumCollection
+    :: (Enum k)
     => Event (CollectionUpdate k a)
     -> SignalGen (Collection k a)
-genericAccumCollection ev = do
-    let toMapOp update = case update of
-            AddItem k a   -> (:) (k, a)
-            RemoveItem k1 -> filter (\(k2, _) -> k1 /= k2)
-    listD <- memoD =<< accumD [] (toMapOp <$> ev)
+accumCollection =
+    genericAccumCollection (Proxy :: Proxy (EnumMap k))
+
+-- | Like "accumCollection", but uses any "Maplike" to maintain the
+-- internal state. This allows the user accumulate collections in the
+-- context of a wider variety of key constrints. The caller must specify
+-- the desired underyling "Maplike" type by providing a "Proxy".
+genericAccumCollection
+    :: forall c k a. (M.Maplike c k)
+    => Proxy (c k)
+    -> Event (CollectionUpdate k a)
+    -> SignalGen (Collection k a)
+genericAccumCollection _ ev = do
+    let toMapOp :: CollectionUpdate k a -> c k a -> c k a
+        toMapOp (AddItem k a) = M.insert k a
+        toMapOp (RemoveItem k) = M.delete k
+    mapping <- accumD M.empty (toMapOp <$> ev)
+    listD <- memoD $ M.toList <$> mapping
     makeCollection listD ev
 
 -- | The primitive interface for creating a 'Collection'. The two
@@ -347,10 +346,10 @@ genericMapToCollection
     => Discrete (c k a)
     -> SignalGen (Collection k (Discrete a))
 genericMapToCollection mapD = do
-    m1 <- delayD M.empty mapD
-    let collDiffs :: Discrete [MapCollEvent k a]
-        collDiffs = diffMaps <$> m1 <*> mapD
-    dispatchCollEvent . flattenE =<< preservesD collDiffs
+    m0 <- delayD M.empty mapD
+    let diffsD = diffMaps <$> m0 <*> mapD
+    diffsE <- flattenE <$> preservesD diffsD
+    dispatchCollEvent (Proxy :: Proxy (c k)) diffsE
 
 -- | Given a pair of generic maps, compute a sequence of "MapCollEvent"s
 -- which would transform the first into the second.
@@ -374,16 +373,17 @@ diffMaps prevmap newmap = concat
         _ -> Nothing
 
 dispatchCollEvent
-    :: (Eq k)
-    => Event (MapCollEvent k a)
+    :: (Eq k, M.Maplike c k)
+    => Proxy (c k)
+    -> Event (MapCollEvent k a)
     -> SignalGen (Collection k (Discrete a))
-dispatchCollEvent mapcollE = do
+dispatchCollEvent mapProxy mapcollE = do
     let f (MCNew k a) = Just $
             AddItem k <$> discreteForKey k a mapcollE
         f (MCRemove k) = Just $ return $ RemoveItem k
         f (MCChange _ _) = Nothing
     updateEv <- generatorE $ justE (f <$> mapcollE)
-    genericAccumCollection updateEv
+    genericAccumCollection mapProxy updateEv
 
 discreteForKey :: Eq k => k -> a -> Event (MapCollEvent k a) -> SignalGen (Discrete a)
 discreteForKey targetKey v0 mapcollE =

--- a/FRP/Euphoria/Internal/Maplike.hs
+++ b/FRP/Euphoria/Internal/Maplike.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleInstances #-}
+
+-- NOTE (asayers): I suppose this module doesn't really belong in
+-- euphoria... but I don't think it deserves its own package.
+module FRP.Euphoria.Internal.Maplike
+    ( Maplike(..)
+    ) where
+
+import Data.Hashable (Hashable)
+import qualified Data.Map            as Map
+import qualified Data.HashMap.Strict as HMS
+import qualified Data.EnumMap.Lazy   as EML
+
+-- | A class for types with an API similar to that of "Data.Map".
+class Maplike c k where
+    union        :: c k v -> c k v -> c k v
+    intersection :: c k v -> c k v -> c k v
+    difference   :: c k v -> c k v -> c k v
+    empty        :: c k v
+    lookup       :: k -> c k v -> Maybe v
+    singleton    :: k -> v -> c k v
+    singleton k v = insert k v empty
+    insert :: k -> v -> c k v -> c k v
+    insert k v m = singleton k v `union` m
+    delete :: k -> c k v -> c k v
+    delete k m =  m `difference` singleton k (error "bug")
+    toList :: c k v -> [(k, v)]
+
+instance Ord k => Maplike Map.Map k where
+    union        = Map.union
+    intersection = Map.intersection
+    difference   = (Map.\\)
+    empty        = Map.empty
+    lookup       = Map.lookup
+    singleton    = Map.singleton
+    insert       = Map.insert
+    delete       = Map.delete
+    toList       = Map.toList
+
+instance Enum k => Maplike EML.EnumMap k where
+    union        = EML.union
+    intersection = EML.intersection
+    difference   = (EML.\\)
+    empty        = EML.empty
+    lookup       = EML.lookup
+    singleton    = EML.singleton
+    insert       = EML.insert
+    delete       = EML.delete
+    toList       = EML.toList
+
+instance (Eq k, Hashable k) => Maplike HMS.HashMap k where
+    union        = HMS.union
+    intersection = HMS.intersection
+    difference   = HMS.difference
+    empty        = HMS.empty
+    lookup       = HMS.lookup
+    singleton    = HMS.singleton
+    insert       = HMS.insert
+    delete       = HMS.delete
+    toList       = HMS.toList

--- a/euphoria.cabal
+++ b/euphoria.cabal
@@ -4,7 +4,7 @@
 name:                euphoria
 version:             0.4.9.0
 synopsis:            Dynamic network FRP with events and continuous values
-description:         
+description:
 
  Euphoria is FRP with practicality.
  .
@@ -62,7 +62,7 @@ license:             PublicDomain
 license-file:        LICENSE
 author:              Takano Akio, Andrew Richards, Liyang HU
 maintainer:          aljee@hyper.cx <Takano Akio>
--- copyright:           
+-- copyright:
 category:            FRP
 build-type:          Simple
 cabal-version:       >=1.8
@@ -74,8 +74,16 @@ source-repository head
 
 library
   exposed-modules:     FRP.Euphoria.Event, FRP.Euphoria.Signal, FRP.Euphoria.Update, FRP.Euphoria.Collection, FRP.Euphoria.Abbrev
-  -- other-modules:       
-  build-depends:       HUnit, base, elerea >= 2.7, data-default, enummapset-th >= 0.6, deepseq
+  -- other-modules:
+  build-depends:       HUnit
+                     , base
+                     , elerea >= 2.7
+                     , data-default
+                     , enummapset-th >= 0.6
+                     , deepseq
+                     , hashable >= 1.2
+                     , containers >= 0.5.5
+                     , unordered-containers >= 0.2.5
 
 test-suite tests
   type:           exitcode-stdio-1.0

--- a/euphoria.cabal
+++ b/euphoria.cabal
@@ -2,7 +2,7 @@
 -- see http://haskell.org/cabal/users-guide/
 
 name:                euphoria
-version:             0.4.9.0
+version:             0.5.0.0
 synopsis:            Dynamic network FRP with events and continuous values
 description:
 
@@ -73,7 +73,7 @@ source-repository head
   location: git://github.com/tsurucapital/euphoria.git
 
 library
-  exposed-modules:     FRP.Euphoria.Event, FRP.Euphoria.Signal, FRP.Euphoria.Update, FRP.Euphoria.Collection, FRP.Euphoria.Abbrev
+  exposed-modules:     FRP.Euphoria.Event, FRP.Euphoria.Signal, FRP.Euphoria.Update, FRP.Euphoria.Collection, FRP.Euphoria.Abbrev, FRP.Euphoria.Internal.Maplike
   -- other-modules:
   build-depends:       HUnit
                      , base >= 4.7

--- a/euphoria.cabal
+++ b/euphoria.cabal
@@ -76,7 +76,7 @@ library
   exposed-modules:     FRP.Euphoria.Event, FRP.Euphoria.Signal, FRP.Euphoria.Update, FRP.Euphoria.Collection, FRP.Euphoria.Abbrev
   -- other-modules:
   build-depends:       HUnit
-                     , base
+                     , base >= 4.7
                      , elerea >= 2.7
                      , data-default
                      , enummapset-th >= 0.6


### PR DESCRIPTION
This MR adds support for `HashMap`s and `Map`s, in addition to `EnumMap`s.

Note: This is an API-breaking change, since it changes the type signature of `mapToCollection`.