### PR TITLE
Fix the counter-intuitive behavior of freezeD

### DIFF
--- a/FRP/Euphoria/Event.hs
+++ b/FRP/Euphoria/Event.hs
@@ -625,11 +625,9 @@ switchDE = switchD
 freezeD :: MonadSignalGen m => Event () -> Discrete a -> m (Discrete a)
 freezeD evt dis = do
     dis' <- memoD dis
-    now <- onCreation ()
     sig <- discreteToSignal dis'
-    initialization <- takeE 1 $ const <$> sig <@> now
-    filteredChanges <- switchD =<< stepperD (changesD dis') (mempty <$ evt)
-    stepperD (error "freezeD: not initialized") $ initialization `mappend` filteredChanges
+    evt1 <- takeE 1 evt
+    switchD =<< stepperD dis' (pure <$> sig <@ evt1)
 
 -- | Convert a 'Signal' to an equivalent 'Discrete'. The resulting discrete
 -- is always considered to \'possibly have changed\'.

--- a/tests/FRP/Euphoria/Event/Test.hs
+++ b/tests/FRP/Euphoria/Event/Test.hs
@@ -51,3 +51,11 @@ case_splitOnE = do
         ev2 <- eventFromList [[], [()], [], [], [()]]
         eventToSignal <$> splitOnE ev2 ev1
     result @?= [[], [[1,2,3,4]], [], [], [[5,6,7,8]]]
+
+case_freezeD :: Assertion
+case_freezeD = do
+    result <- networkToList 5 $ do
+        ev <- eventFromList [[], [], [()], [], [()]]
+        dis <- signalToDiscrete <$> signalFromList [1..]
+        discreteToSignal =<< freezeD ev dis
+    result @?= [1, 2, 3, 3, 3 :: Int]


### PR DESCRIPTION
The [new test case for freezeD](https://github.com/tsurucapital/euphoria/commit/92f625a5b4cd9ebf48addd089bfa79af75208b26), which I think is the most intuitive behavior, fails with the current implementation. This PR fixes the behavior to match the test case.
